### PR TITLE
Add mail edge connector

### DIFF
--- a/AG1_AetherBus/agent_bus_minimal.py
+++ b/AG1_AetherBus/agent_bus_minimal.py
@@ -65,6 +65,24 @@ async def register_with_tg_handler(config, redis):
     print(f"[AG1_AetherBus][REGISTER] Sent registration envelope for {config['agent_name']} to {channel}")
 
 
+async def register_with_llm_handler(config, redis):
+    """Send a registration envelope to the LLM edge handler."""
+    envelope = Envelope(
+        role="agent",
+        envelope_type="register",
+        agent_name=config["agent_name"],
+        content={
+            "provider": config.get("llm_provider", "openai")
+        },
+        timestamp=datetime.datetime.utcnow().isoformat() + "Z"
+    )
+    channel = StreamKeyBuilder().edge_register("llm")
+    await publish_envelope(redis, channel, envelope)
+    print(
+        f"[AG1_AetherBus][REGISTER] Sent LLM registration envelope for {config['agent_name']} to {channel}"
+    )
+
+
 async def register_with_a2a_handler(config: dict, redis: Redis) -> None:
     """
     Register an agent with the A2A edge handler.

--- a/AG1_AetherBus/bus_adapter.py
+++ b/AG1_AetherBus/bus_adapter.py
@@ -220,4 +220,5 @@ async def main():
     except asyncio.CancelledError:
         pass
 
-asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/AG1_AetherBus/bus_adapterV2.py
+++ b/AG1_AetherBus/bus_adapterV2.py
@@ -45,6 +45,11 @@ class BusAdapterV2:
         for pattern in self.patterns:
             await self._subscribe_pattern(pattern, self.core)
 
+    async def stop(self):
+        """Cancel all running subscription tasks."""
+        for pattern in list(self._running_subscription_tasks.keys()):
+            await self.remove_subscription(pattern)
+
     async def _subscribe_pattern(
         self,
         pattern: str,

--- a/AG1_AetherBus/handlers/llm_edge_handler.py
+++ b/AG1_AetherBus/handlers/llm_edge_handler.py
@@ -1,0 +1,106 @@
+import asyncio
+import os
+import json
+import argparse
+from dotenv import load_dotenv
+from redis.asyncio import Redis
+
+from AG1_AetherBus.bus import build_redis_url, publish_envelope
+from AG1_AetherBus.agent_bus_minimal import start_bus_subscriptions
+from AG1_AetherBus.envelope import Envelope
+from AG1_AetherBus.keys import StreamKeyBuilder
+
+try:
+    import openai
+except ImportError:  # pragma: no cover - openai optional for tests
+    openai = None
+
+try:
+    import yaml  # optional for YAML configs
+except Exception:  # pragma: no cover - yaml may be absent in minimal env
+    yaml = None
+
+def load_llm_config(path: str | None = None) -> dict:
+    """Load Azure OpenAI credentials from a file or environment."""
+    load_dotenv()
+    config: dict = {}
+    if path and os.path.isfile(path):
+        with open(path, "r") as f:
+            if path.endswith(('.yml', '.yaml')) and yaml:
+                config = yaml.safe_load(f) or {}
+            else:
+                config = json.load(f)
+    return {
+        "endpoint": os.getenv("AZURE_OPENAI_ENDPOINT", config.get("endpoint")),
+        "api_key": os.getenv("AZURE_OPENAI_API_KEY", config.get("api_key")),
+        "deployment": os.getenv("AZURE_OPENAI_DEPLOYMENT", config.get("deployment")),
+        "api_version": os.getenv(
+            "AZURE_OPENAI_API_VERSION",
+            config.get("api_version", "2024-02-15-preview"),
+        ),
+    }
+
+keys = StreamKeyBuilder()
+REQUEST_STREAM = keys.edge_stream("llm", "requests")
+
+async def handle_llm_request(env: Envelope, redis: Redis, cfg: dict):
+    """Process incoming LLM requests and publish responses."""
+    prompt = None
+    if isinstance(env.content, dict):
+        prompt = env.content.get("prompt") or env.content.get("text")
+    if not prompt:
+        return
+    reply_to = env.reply_to or keys.edge_response("llm", env.user_id or env.agent_name)
+
+    result_text = ""
+    if openai and cfg.get("endpoint") and cfg.get("api_key") and cfg.get("deployment"):
+        openai.api_type = "azure"
+        openai.api_base = cfg["endpoint"]
+        openai.api_version = cfg["api_version"]
+        openai.api_key = cfg["api_key"]
+        try:
+            resp = await openai.ChatCompletion.acreate(
+                engine=cfg["deployment"],
+                messages=[{"role": "user", "content": prompt}]
+            )
+            result_text = resp.choices[0].message.content
+        except Exception as e:  # pragma: no cover - network errors
+            result_text = f"LLM error: {e}"
+    else:
+        result_text = "LLM backend not configured"
+
+    response_env = Envelope(
+        role="llm",
+        content={"text": result_text},
+        user_id=env.user_id,
+        agent_name="llm_edge",
+        correlation_id=env.correlation_id,
+        envelope_type="message",
+    )
+    await publish_envelope(redis, reply_to, response_env)
+
+async def main(config_path: str | None = None):
+    cfg = load_llm_config(config_path)
+    redis = Redis.from_url(build_redis_url())
+    await start_bus_subscriptions(
+        redis=redis,
+        patterns=[REQUEST_STREAM],
+        group="llm_edge",
+        handler=lambda env: handle_llm_request(env, redis, cfg)
+    )
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="LLM Edge Handler")
+    parser.add_argument(
+        "--config",
+        help="Path to JSON/YAML file with Azure OpenAI credentials",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    try:
+        asyncio.run(main(args.config))
+    except KeyboardInterrupt:
+        pass

--- a/AG1_AetherBus/handlers/mail_edge/mail_edge_handler.py
+++ b/AG1_AetherBus/handlers/mail_edge/mail_edge_handler.py
@@ -1,0 +1,139 @@
+import asyncio
+import imaplib
+import smtplib
+from email.message import EmailMessage
+from email import message_from_bytes
+from redis.asyncio import Redis
+from AG1_AetherBus.envelope import Envelope
+from AG1_AetherBus.keys import StreamKeyBuilder
+from AG1_AetherBus.bus import publish_envelope, subscribe, build_redis_url
+from AG1_AetherBus.agent_bus_minimal import start_bus_subscriptions
+
+keys = StreamKeyBuilder()
+REGISTER_STREAM = keys.edge_register("mail")
+
+registered_accounts: dict[str, dict] = {}
+
+async def fetch_messages(cfg: dict) -> list[dict]:
+    """Fetch unseen emails for the account without deleting them."""
+    def _inner():
+        host = cfg.get("imap_host", "imap.gmail.com")
+        username = cfg.get("username")
+        password = cfg.get("password")
+        folder = cfg.get("folder", "INBOX")
+        messages = []
+        with imaplib.IMAP4_SSL(host) as M:
+            M.login(username, password)
+            M.select(folder)
+            typ, data = M.search(None, "UNSEEN")
+            if typ != 'OK':
+                return []
+            for num in data[0].split():
+                typ, msg_data = M.fetch(num, '(RFC822)')
+                if typ != 'OK':
+                    continue
+                msg = message_from_bytes(msg_data[0][1])
+                subject = msg.get('Subject', '')
+                body = ''
+                if msg.is_multipart():
+                    for part in msg.walk():
+                        ctype = part.get_content_type()
+                        if ctype == 'text/plain' and not part.get('Content-Disposition'):
+                            body = part.get_payload(decode=True).decode(part.get_content_charset() or 'utf-8', 'ignore')
+                            break
+                else:
+                    body = msg.get_payload(decode=True).decode(msg.get_content_charset() or 'utf-8', 'ignore')
+                messages.append({'uid': num.decode(), 'subject': subject, 'body': body})
+        return messages
+    return await asyncio.to_thread(_inner)
+
+async def poll_account(redis: Redis, cfg: dict):
+    """Periodically check the mailbox and publish new emails to the agent."""
+    seen: set[str] = set()
+    agent_name = cfg.get("agent_name")
+    user_stream = keys.agent_inbox(agent_name)
+    reply_stream = keys.edge_response("mail", cfg.get("username"))
+    while True:
+        try:
+            msgs = await fetch_messages(cfg)
+            for m in msgs:
+                if m['uid'] in seen:
+                    continue
+                seen.add(m['uid'])
+                env = Envelope(
+                    role="user",
+                    user_id=cfg.get("username"),
+                    agent_name=agent_name,
+                    envelope_type="message",
+                    content={"subject": m['subject'], "text": m['body']},
+                    reply_to=reply_stream
+                )
+                await publish_envelope(redis, user_stream, env)
+        except Exception as e:
+            print(f"[MAIL_EDGE] Error polling {cfg.get('username')}: {e}")
+        await asyncio.sleep(cfg.get("poll_interval", 30))
+
+def send_email(cfg: dict, to_addr: str, subject: str, body: str):
+    host = cfg.get("smtp_host", "smtp.gmail.com")
+    port = int(cfg.get("smtp_port", 587))
+    username = cfg.get("smtp_user", cfg.get("username"))
+    password = cfg.get("smtp_password", cfg.get("password"))
+    msg = EmailMessage()
+    msg['From'] = username
+    msg['To'] = to_addr
+    msg['Subject'] = subject
+    msg.set_content(body)
+    with smtplib.SMTP(host, port) as s:
+        s.starttls()
+        s.login(username, password)
+        s.send_message(msg)
+
+async def handle_agent_reply(env: Envelope, cfg: dict):
+    if env.content and isinstance(env.content, dict):
+        text = env.content.get("text")
+        if text:
+            await asyncio.to_thread(
+                send_email,
+                cfg,
+                cfg.get("username"),
+                f"Agent reply: {env.agent_name}",
+                text
+            )
+
+async def handle_register(env: Envelope, redis: Redis):
+    if env.envelope_type != "register":
+        return
+    cfg = env.content or {}
+    username = cfg.get("username")
+    if not username:
+        print("[MAIL_EDGE] Registration missing username")
+        return
+    cfg["agent_name"] = env.agent_name
+    registered_accounts[username] = cfg
+    asyncio.create_task(poll_account(redis, cfg))
+    asyncio.create_task(
+        subscribe(
+            redis,
+            keys.edge_response("mail", username),
+            lambda e: handle_agent_reply(e, cfg),
+            group=f"mail_edge_{username}"
+        )
+    )
+    print(f"[MAIL_EDGE] Registered mail account {username} for agent {env.agent_name}")
+
+async def main():
+    redis = Redis.from_url(build_redis_url())
+    await start_bus_subscriptions(
+        redis=redis,
+        patterns=[REGISTER_STREAM],
+        group="mail_edge",
+        handler=lambda env: handle_register(env, redis)
+    )
+
+from AG1_AetherBus.agent_bus_minimal import start_bus_subscriptions
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ All keys are prefixed with the namespace (default: `AG1`).
 | Flow Output      | `AG1:flow:{flow_id}:output`             | `AG1:flow:myflow:output`      |
 | Session Stream   | `AG1:session:{session_code}:stream`     | `AG1:session:xyz123:stream`   |
 | Edge Register    | `AG1:edge:{platform}:register`          | `AG1:edge:telegram:register`  |
+| LLM Requests     | `AG1:edge:llm:requests`                 | `AG1:edge:llm:requests`       |
+| LLM Register     | `AG1:edge:llm:register`                 | `AG1:edge:llm:register`       |
+| Mail Register    | `AG1:edge:mail:register`                | `AG1:edge:mail:register`      |
 
 > **Note:** Always use the `StreamKeyBuilder` class to generate these keys in code.
 

--- a/docs/README_LLM_EDGE.md
+++ b/docs/README_LLM_EDGE.md
@@ -1,0 +1,47 @@
+# AG1 Core Bus – LLM Edge Handler (Azure)
+
+This edge connector exposes Azure OpenAI models via the AG1 bus. It subscribes to
+`AG1:edge:llm:requests`, forwards prompts to your Azure deployment, then publishes
+responses back to the provided reply stream.
+
+## Configuration
+Credentials can be provided via environment variables or a config file.
+
+### Environment Variables
+- `AZURE_OPENAI_ENDPOINT` – Your Azure OpenAI endpoint URL
+- `AZURE_OPENAI_API_KEY` – API key for the service
+- `AZURE_OPENAI_DEPLOYMENT` – Chat completion deployment name
+- `AZURE_OPENAI_API_VERSION` – API version (default `2024-02-15-preview`)
+
+### Config File
+You may supply a JSON or YAML file with the same keys using `--config`.
+An example config is provided in `examples/llm_edge_config.yaml`:
+
+```yaml
+endpoint: https://your-endpoint.openai.azure.com/
+api_key: sk-...
+deployment: gpt-35-turbo
+api_version: 2024-02-15-preview
+```
+
+## Running
+```
+python -m AG1_AetherBus.handlers.llm_edge_handler --config /path/to/llm.yaml
+```
+If `--config` is omitted, the handler reads credentials from environment variables.
+Ensure the Redis connection is configured via standard bus variables.
+
+### Registration
+Agents can announce their ability to use the LLM edge by publishing a
+registration Envelope to `AG1:edge:llm:register`. The helper
+`register_with_llm_handler` in `agent_bus_minimal.py` shows how to
+construct this envelope.
+
+## Message Flow
+1. Client publishes a prompt to `AG1:edge:llm:requests` with a `reply_to` stream
+2. The handler calls the Azure OpenAI Chat Completion API
+3. The response is wrapped in an Envelope and published to the `reply_to` stream
+
+---
+Contributions are welcome! Please update documentation and add tests for any new
+features.

--- a/docs/README_MAIL_EDGE.md
+++ b/docs/README_MAIL_EDGE.md
@@ -1,0 +1,34 @@
+# AG1 Core Bus – Mail Edge Handler
+
+The mail edge connector bridges IMAP/SMTP accounts to the AG1 bus. Each agent can register an email account so incoming emails are delivered to the agent inbox and agent replies are sent back via SMTP.
+
+## Registration
+Agents publish a registration envelope to `AG1:edge:mail:register` containing the IMAP/SMTP credentials:
+
+```json
+{
+  "envelope_type": "register",
+  "agent_name": "MuseMail",
+  "content": {
+    "username": "mybot@example.com",
+    "password": "app-password",
+    "imap_host": "imap.gmail.com",
+    "smtp_host": "smtp.gmail.com",
+    "smtp_port": 587
+  }
+}
+```
+An example configuration file is available at `examples/mail_edge_config.json`.
+
+On registration the handler starts polling the mailbox and subscribes to the agent reply channel `AG1:edge:mail:<username>:response`.
+
+## Message Flow
+1. New emails are fetched (but not deleted) via IMAP.
+2. Each message is published to the agent inbox `AG1:agent:<agent_name>:inbox` with the reply stream set to `AG1:edge:mail:<username>:response`.
+3. Replies from the agent on that stream are sent back to the mailbox via SMTP.
+
+## Running
+```
+python -m AG1_AetherBus.handlers.mail_edge.mail_edge_handler
+```
+Make sure the standard Redis environment variables are configured.

--- a/examples/llm_edge_config.yaml
+++ b/examples/llm_edge_config.yaml
@@ -1,0 +1,4 @@
+endpoint: https://your-endpoint.openai.azure.com/
+api_key: AZURE_API_KEY
+deployment: gpt-35-turbo
+api_version: 2024-02-15-preview

--- a/examples/mail_edge_config.json
+++ b/examples/mail_edge_config.json
@@ -1,0 +1,8 @@
+{
+  "username": "mybot@example.com",
+  "password": "app-password",
+  "imap_host": "imap.gmail.com",
+  "smtp_host": "smtp.gmail.com",
+  "smtp_port": 587
+}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 redis==5.2.1
 aiohttp
 python-dotenv
+openai
+PyYAML


### PR DESCRIPTION
## Summary
- introduce `mail_edge` handler to bridge IMAP/SMTP accounts
- document mail edge usage in new `README_MAIL_EDGE.md`
- provide example `mail_edge_config.json`
- list `AG1:edge:mail:register` in key table

## Testing
- `pytest -q` *(fails: pyenv not configured)*

------
https://chatgpt.com/codex/tasks/task_e_684251348318832285b0c43a692f882d