### PR TITLE
Add Nostr edge connector

### DIFF
--- a/AG1_AetherBus/agent_bus_minimal.py
+++ b/AG1_AetherBus/agent_bus_minimal.py
@@ -65,6 +65,43 @@ async def register_with_tg_handler(config, redis):
     print(f"[AG1_AetherBus][REGISTER] Sent registration envelope for {config['agent_name']} to {channel}")
 
 
+async def register_with_llm_handler(config, redis):
+    """Send a registration envelope to the LLM edge handler."""
+    envelope = Envelope(
+        role="agent",
+        envelope_type="register",
+        agent_name=config["agent_name"],
+        content={
+            "provider": config.get("llm_provider", "openai")
+        },
+        timestamp=datetime.datetime.utcnow().isoformat() + "Z"
+    )
+    channel = StreamKeyBuilder().edge_register("llm")
+    await publish_envelope(redis, channel, envelope)
+    print(
+        f"[AG1_AetherBus][REGISTER] Sent LLM registration envelope for {config['agent_name']} to {channel}"
+    )
+
+
+async def register_with_nostr_handler(config, redis):
+    """Send a registration envelope to the Nostr edge handler."""
+    envelope = Envelope(
+        role="agent",
+        envelope_type="register",
+        agent_name=config["agent_name"],
+        content={
+            "pubkey": config.get("pubkey"),
+            "relay": config.get("relay")
+        },
+        timestamp=datetime.datetime.utcnow().isoformat() + "Z"
+    )
+    channel = StreamKeyBuilder().edge_register("nostr")
+    await publish_envelope(redis, channel, envelope)
+    print(
+        f"[AG1_AEtherBus][REGISTER] Sent Nostr registration envelope for {config['agent_name']} to {channel}"
+    )
+
+
 async def register_with_a2a_handler(config: dict, redis: Redis) -> None:
     """
     Register an agent with the A2A edge handler.

--- a/AG1_AetherBus/agent_registry.py
+++ b/AG1_AetherBus/agent_registry.py
@@ -1,0 +1,26 @@
+import time
+from typing import Optional, Dict
+from redis.asyncio import Redis
+
+REGISTRY_SET_KEY = "AG1:registry:agents"
+
+async def register_agent(redis: Redis, agent_id: str, metadata: Optional[Dict[str, str]] = None) -> bool:
+    """Register an agent ID in the global registry.
+
+    Returns True if the ID was newly added, False if it already existed."""
+    added = await redis.sadd(REGISTRY_SET_KEY, agent_id)
+    if metadata is None:
+        metadata = {}
+    metadata.setdefault("registered_at", str(time.time()))
+    if added:
+        await redis.hset(f"AG1:registry:info:{agent_id}", mapping=metadata)
+    return bool(added)
+
+async def unregister_agent(redis: Redis, agent_id: str) -> None:
+    """Remove the agent ID from the registry."""
+    await redis.srem(REGISTRY_SET_KEY, agent_id)
+    await redis.delete(f"AG1:registry:info:{agent_id}")
+
+async def is_registered(redis: Redis, agent_id: str) -> bool:
+    """Check if an agent ID is registered."""
+    return bool(await redis.sismember(REGISTRY_SET_KEY, agent_id))

--- a/AG1_AetherBus/bus_adapter.py
+++ b/AG1_AetherBus/bus_adapter.py
@@ -220,4 +220,5 @@ async def main():
     except asyncio.CancelledError:
         pass
 
-asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/AG1_AetherBus/bus_adapterV2.py
+++ b/AG1_AetherBus/bus_adapterV2.py
@@ -45,6 +45,11 @@ class BusAdapterV2:
         for pattern in self.patterns:
             await self._subscribe_pattern(pattern, self.core)
 
+    async def stop(self):
+        """Cancel all running subscription tasks."""
+        for pattern in list(self._running_subscription_tasks.keys()):
+            await self.remove_subscription(pattern)
+
     async def _subscribe_pattern(
         self,
         pattern: str,

--- a/AG1_AetherBus/bus_adapterV2.py
+++ b/AG1_AetherBus/bus_adapterV2.py
@@ -7,6 +7,8 @@ from AG1_AetherBus.bus import publish_envelope  # low-level xadd helper
 from AG1_AetherBus.envelope import Envelope
 from AG1_AetherBus.agent_bus_minimal import start_bus_subscriptions
 import json
+# Registry helpers for simple handshake
+from AG1_AetherBus.agent_registry import register_agent, unregister_agent
 # Redis specific imports
 from redis.asyncio import Redis as AsyncRedis # For type hinting and explicit async Redis client
 from redis.exceptions import ConnectionError as RedisConnectionError # For specific exception handling
@@ -42,6 +44,8 @@ class BusAdapterV2:
         """
         Subscribe to all statically configured patterns.
         """
+        # ensure agent is registered before listening
+        await register_agent(self.redis, self.agent_id)
         for pattern in self.patterns:
             await self._subscribe_pattern(pattern, self.core)
 
@@ -49,6 +53,7 @@ class BusAdapterV2:
         """Cancel all running subscription tasks."""
         for pattern in list(self._running_subscription_tasks.keys()):
             await self.remove_subscription(pattern)
+        await unregister_agent(self.redis, self.agent_id)
 
     async def _subscribe_pattern(
         self,

--- a/AG1_AetherBus/handlers/llm_edge_handler.py
+++ b/AG1_AetherBus/handlers/llm_edge_handler.py
@@ -1,0 +1,106 @@
+import asyncio
+import os
+import json
+import argparse
+from dotenv import load_dotenv
+from redis.asyncio import Redis
+
+from AG1_AetherBus.bus import build_redis_url, publish_envelope
+from AG1_AetherBus.agent_bus_minimal import start_bus_subscriptions
+from AG1_AetherBus.envelope import Envelope
+from AG1_AetherBus.keys import StreamKeyBuilder
+
+try:
+    import openai
+except ImportError:  # pragma: no cover - openai optional for tests
+    openai = None
+
+try:
+    import yaml  # optional for YAML configs
+except Exception:  # pragma: no cover - yaml may be absent in minimal env
+    yaml = None
+
+def load_llm_config(path: str | None = None) -> dict:
+    """Load Azure OpenAI credentials from a file or environment."""
+    load_dotenv()
+    config: dict = {}
+    if path and os.path.isfile(path):
+        with open(path, "r") as f:
+            if path.endswith(('.yml', '.yaml')) and yaml:
+                config = yaml.safe_load(f) or {}
+            else:
+                config = json.load(f)
+    return {
+        "endpoint": os.getenv("AZURE_OPENAI_ENDPOINT", config.get("endpoint")),
+        "api_key": os.getenv("AZURE_OPENAI_API_KEY", config.get("api_key")),
+        "deployment": os.getenv("AZURE_OPENAI_DEPLOYMENT", config.get("deployment")),
+        "api_version": os.getenv(
+            "AZURE_OPENAI_API_VERSION",
+            config.get("api_version", "2024-02-15-preview"),
+        ),
+    }
+
+keys = StreamKeyBuilder()
+REQUEST_STREAM = keys.edge_stream("llm", "requests")
+
+async def handle_llm_request(env: Envelope, redis: Redis, cfg: dict):
+    """Process incoming LLM requests and publish responses."""
+    prompt = None
+    if isinstance(env.content, dict):
+        prompt = env.content.get("prompt") or env.content.get("text")
+    if not prompt:
+        return
+    reply_to = env.reply_to or keys.edge_response("llm", env.user_id or env.agent_name)
+
+    result_text = ""
+    if openai and cfg.get("endpoint") and cfg.get("api_key") and cfg.get("deployment"):
+        openai.api_type = "azure"
+        openai.api_base = cfg["endpoint"]
+        openai.api_version = cfg["api_version"]
+        openai.api_key = cfg["api_key"]
+        try:
+            resp = await openai.ChatCompletion.acreate(
+                engine=cfg["deployment"],
+                messages=[{"role": "user", "content": prompt}]
+            )
+            result_text = resp.choices[0].message.content
+        except Exception as e:  # pragma: no cover - network errors
+            result_text = f"LLM error: {e}"
+    else:
+        result_text = "LLM backend not configured"
+
+    response_env = Envelope(
+        role="llm",
+        content={"text": result_text},
+        user_id=env.user_id,
+        agent_name="llm_edge",
+        correlation_id=env.correlation_id,
+        envelope_type="message",
+    )
+    await publish_envelope(redis, reply_to, response_env)
+
+async def main(config_path: str | None = None):
+    cfg = load_llm_config(config_path)
+    redis = Redis.from_url(build_redis_url())
+    await start_bus_subscriptions(
+        redis=redis,
+        patterns=[REQUEST_STREAM],
+        group="llm_edge",
+        handler=lambda env: handle_llm_request(env, redis, cfg)
+    )
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="LLM Edge Handler")
+    parser.add_argument(
+        "--config",
+        help="Path to JSON/YAML file with Azure OpenAI credentials",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    try:
+        asyncio.run(main(args.config))
+    except KeyboardInterrupt:
+        pass

--- a/AG1_AetherBus/handlers/mail_edge/mail_edge_handler.py
+++ b/AG1_AetherBus/handlers/mail_edge/mail_edge_handler.py
@@ -1,0 +1,139 @@
+import asyncio
+import imaplib
+import smtplib
+from email.message import EmailMessage
+from email import message_from_bytes
+from redis.asyncio import Redis
+from AG1_AetherBus.envelope import Envelope
+from AG1_AetherBus.keys import StreamKeyBuilder
+from AG1_AetherBus.bus import publish_envelope, subscribe, build_redis_url
+from AG1_AetherBus.agent_bus_minimal import start_bus_subscriptions
+
+keys = StreamKeyBuilder()
+REGISTER_STREAM = keys.edge_register("mail")
+
+registered_accounts: dict[str, dict] = {}
+
+async def fetch_messages(cfg: dict) -> list[dict]:
+    """Fetch unseen emails for the account without deleting them."""
+    def _inner():
+        host = cfg.get("imap_host", "imap.gmail.com")
+        username = cfg.get("username")
+        password = cfg.get("password")
+        folder = cfg.get("folder", "INBOX")
+        messages = []
+        with imaplib.IMAP4_SSL(host) as M:
+            M.login(username, password)
+            M.select(folder)
+            typ, data = M.search(None, "UNSEEN")
+            if typ != 'OK':
+                return []
+            for num in data[0].split():
+                typ, msg_data = M.fetch(num, '(RFC822)')
+                if typ != 'OK':
+                    continue
+                msg = message_from_bytes(msg_data[0][1])
+                subject = msg.get('Subject', '')
+                body = ''
+                if msg.is_multipart():
+                    for part in msg.walk():
+                        ctype = part.get_content_type()
+                        if ctype == 'text/plain' and not part.get('Content-Disposition'):
+                            body = part.get_payload(decode=True).decode(part.get_content_charset() or 'utf-8', 'ignore')
+                            break
+                else:
+                    body = msg.get_payload(decode=True).decode(msg.get_content_charset() or 'utf-8', 'ignore')
+                messages.append({'uid': num.decode(), 'subject': subject, 'body': body})
+        return messages
+    return await asyncio.to_thread(_inner)
+
+async def poll_account(redis: Redis, cfg: dict):
+    """Periodically check the mailbox and publish new emails to the agent."""
+    seen: set[str] = set()
+    agent_name = cfg.get("agent_name")
+    user_stream = keys.agent_inbox(agent_name)
+    reply_stream = keys.edge_response("mail", cfg.get("username"))
+    while True:
+        try:
+            msgs = await fetch_messages(cfg)
+            for m in msgs:
+                if m['uid'] in seen:
+                    continue
+                seen.add(m['uid'])
+                env = Envelope(
+                    role="user",
+                    user_id=cfg.get("username"),
+                    agent_name=agent_name,
+                    envelope_type="message",
+                    content={"subject": m['subject'], "text": m['body']},
+                    reply_to=reply_stream
+                )
+                await publish_envelope(redis, user_stream, env)
+        except Exception as e:
+            print(f"[MAIL_EDGE] Error polling {cfg.get('username')}: {e}")
+        await asyncio.sleep(cfg.get("poll_interval", 30))
+
+def send_email(cfg: dict, to_addr: str, subject: str, body: str):
+    host = cfg.get("smtp_host", "smtp.gmail.com")
+    port = int(cfg.get("smtp_port", 587))
+    username = cfg.get("smtp_user", cfg.get("username"))
+    password = cfg.get("smtp_password", cfg.get("password"))
+    msg = EmailMessage()
+    msg['From'] = username
+    msg['To'] = to_addr
+    msg['Subject'] = subject
+    msg.set_content(body)
+    with smtplib.SMTP(host, port) as s:
+        s.starttls()
+        s.login(username, password)
+        s.send_message(msg)
+
+async def handle_agent_reply(env: Envelope, cfg: dict):
+    if env.content and isinstance(env.content, dict):
+        text = env.content.get("text")
+        if text:
+            await asyncio.to_thread(
+                send_email,
+                cfg,
+                cfg.get("username"),
+                f"Agent reply: {env.agent_name}",
+                text
+            )
+
+async def handle_register(env: Envelope, redis: Redis):
+    if env.envelope_type != "register":
+        return
+    cfg = env.content or {}
+    username = cfg.get("username")
+    if not username:
+        print("[MAIL_EDGE] Registration missing username")
+        return
+    cfg["agent_name"] = env.agent_name
+    registered_accounts[username] = cfg
+    asyncio.create_task(poll_account(redis, cfg))
+    asyncio.create_task(
+        subscribe(
+            redis,
+            keys.edge_response("mail", username),
+            lambda e: handle_agent_reply(e, cfg),
+            group=f"mail_edge_{username}"
+        )
+    )
+    print(f"[MAIL_EDGE] Registered mail account {username} for agent {env.agent_name}")
+
+async def main():
+    redis = Redis.from_url(build_redis_url())
+    await start_bus_subscriptions(
+        redis=redis,
+        patterns=[REGISTER_STREAM],
+        group="mail_edge",
+        handler=lambda env: handle_register(env, redis)
+    )
+
+from AG1_AetherBus.agent_bus_minimal import start_bus_subscriptions
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/AG1_AetherBus/handlers/nostr_edge_handler.py
+++ b/AG1_AetherBus/handlers/nostr_edge_handler.py
@@ -1,0 +1,134 @@
+import asyncio
+import json
+import time
+from typing import Dict
+
+from redis.asyncio import Redis
+
+from AG1_AetherBus.bus import build_redis_url, publish_envelope, subscribe
+from AG1_AetherBus.agent_bus_minimal import start_bus_subscriptions
+from AG1_AetherBus.envelope import Envelope
+from AG1_AetherBus.keys import StreamKeyBuilder
+
+try:
+    import websockets  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    websockets = None
+
+keys = StreamKeyBuilder()
+REGISTER_STREAM = keys.edge_register("nostr")
+DEFAULT_RELAY = "wss://relay.damus.io"
+
+registered_agents: Dict[str, dict] = {}
+
+
+async def nostr_listen(redis: Redis, cfg: dict) -> None:
+    """Listen for events mentioning our pubkey and publish them to the agent."""
+    pubkey = cfg["pubkey"]
+    relay = cfg.get("relay", DEFAULT_RELAY)
+    if not websockets:
+        print("[NOSTR_EDGE] websockets package not installed")
+        return
+    while True:
+        try:
+            async with websockets.connect(relay) as ws:  # type: ignore
+                sub_id = f"sub_{pubkey[:8]}"
+                req = [
+                    "REQ",
+                    sub_id,
+                    {"kinds": [1], "tags": {"#p": [pubkey]}},
+                ]
+                await ws.send(json.dumps(req))
+                while True:
+                    msg = await ws.recv()
+                    evt = json.loads(msg)
+                    if evt and evt[0] == "EVENT" and len(evt) > 2:
+                        data = evt[2]
+                        content = data.get("content", "")
+                        sender = data.get("pubkey")
+                        env = Envelope(
+                            role="user",
+                            user_id=sender,
+                            agent_name=cfg["agent_name"],
+                            content={"text": content},
+                            envelope_type="message",
+                            reply_to=keys.edge_response("nostr", sender),
+                        )
+                        await publish_envelope(
+                            redis, keys.agent_inbox(cfg["agent_name"]), env
+                        )
+        except Exception as e:
+            print(f"[NOSTR_EDGE] Listen error {e}, reconnecting in 5s")
+            await asyncio.sleep(5)
+
+
+async def send_note(cfg: dict, to_pubkey: str, text: str) -> None:
+    """Send a basic text note to the relay."""
+    if not websockets:
+        print("[NOSTR_EDGE] websockets package not installed")
+        return
+    relay = cfg.get("relay", DEFAULT_RELAY)
+    try:
+        async with websockets.connect(relay) as ws:  # type: ignore
+            event = {
+                "content": text,
+                "pubkey": cfg["pubkey"],
+                "created_at": int(time.time()),
+                "kind": 1,
+                "tags": [["p", to_pubkey]],
+            }
+            await ws.send(json.dumps(["EVENT", event]))
+    except Exception as e:
+        print(f"[NOSTR_EDGE] Failed to send note: {e}")
+
+
+async def handle_agent_reply(env: Envelope, cfg: dict) -> None:
+    content = ""
+    if isinstance(env.content, dict):
+        content = env.content.get("text") or ""
+    else:
+        content = str(env.content)
+    if not content:
+        return
+    to_pubkey = env.user_id or cfg.get("pubkey")
+    if to_pubkey:
+        await send_note(cfg, to_pubkey, content)
+
+
+async def handle_register(env: Envelope, redis: Redis) -> None:
+    if env.envelope_type != "register":
+        return
+    cfg = env.content or {}
+    pubkey = cfg.get("pubkey")
+    if not pubkey:
+        print("[NOSTR_EDGE] Registration missing pubkey")
+        return
+    cfg["agent_name"] = env.agent_name
+    registered_agents[pubkey] = cfg
+    asyncio.create_task(nostr_listen(redis, cfg))
+    asyncio.create_task(
+        subscribe(
+            redis,
+            keys.edge_response("nostr", pubkey),
+            lambda e: handle_agent_reply(e, cfg),
+            group=f"nostr_edge_{pubkey}",
+        )
+    )
+    print(f"[NOSTR_EDGE] Registered agent {env.agent_name} for pubkey {pubkey}")
+
+
+async def main() -> None:
+    redis = Redis.from_url(build_redis_url())
+    await start_bus_subscriptions(
+        redis=redis,
+        patterns=[REGISTER_STREAM],
+        group="nostr_edge",
+        handler=lambda env: handle_register(env, redis),
+    )
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/README.md
+++ b/README.md
@@ -334,6 +334,12 @@ Envelope(
   3. Implement/extend the edge handler to process new edge registrations.
 - See the `register_with_tg_handler` function in `agent_bus_minimal.py` for a template and TODO notes.
 
+### Agent Registry & Handshake
+`BusAdapterV2` registers its `agent_id` in a Redis set (`AG1:registry:agents`) when started
+and removes it on shutdown.  This provides a simple mechanism to ensure IDs are
+unique on the network. Other components can check registration status using
+`is_registered` from `AG1_AetherBus.agent_registry`.
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -334,3 +334,8 @@ Envelope(
   3. Implement/extend the edge handler to process new edge registrations.
 - See the `register_with_tg_handler` function in `agent_bus_minimal.py` for a template and TODO notes.
 
+
+---
+
+### Experimental Attestation Layer
+An optional proof-of-concept signing system lives under `feature/experimental_attestation`. It provides helper functions to sign and verify envelopes using HMAC and stores attestations in a local SQLite ledger. The bus itself is unchanged; use the provided `publish_with_attestation` and `subscribe_with_attestation` helpers if you wish to enable this layer.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ All keys are prefixed with the namespace (default: `AG1`).
 | Flow Output      | `AG1:flow:{flow_id}:output`             | `AG1:flow:myflow:output`      |
 | Session Stream   | `AG1:session:{session_code}:stream`     | `AG1:session:xyz123:stream`   |
 | Edge Register    | `AG1:edge:{platform}:register`          | `AG1:edge:telegram:register`  |
+| LLM Requests     | `AG1:edge:llm:requests`                 | `AG1:edge:llm:requests`       |
+| LLM Register     | `AG1:edge:llm:register`                 | `AG1:edge:llm:register`       |
+| Mail Register    | `AG1:edge:mail:register`                | `AG1:edge:mail:register`      |
+| Nostr Register   | `AG1:edge:nostr:register`               | `AG1:edge:nostr:register`     |
 
 > **Note:** Always use the `StreamKeyBuilder` class to generate these keys in code.
 

--- a/docs/README_LLM_EDGE.md
+++ b/docs/README_LLM_EDGE.md
@@ -1,0 +1,47 @@
+# AG1 Core Bus – LLM Edge Handler (Azure)
+
+This edge connector exposes Azure OpenAI models via the AG1 bus. It subscribes to
+`AG1:edge:llm:requests`, forwards prompts to your Azure deployment, then publishes
+responses back to the provided reply stream.
+
+## Configuration
+Credentials can be provided via environment variables or a config file.
+
+### Environment Variables
+- `AZURE_OPENAI_ENDPOINT` – Your Azure OpenAI endpoint URL
+- `AZURE_OPENAI_API_KEY` – API key for the service
+- `AZURE_OPENAI_DEPLOYMENT` – Chat completion deployment name
+- `AZURE_OPENAI_API_VERSION` – API version (default `2024-02-15-preview`)
+
+### Config File
+You may supply a JSON or YAML file with the same keys using `--config`.
+An example config is provided in `examples/llm_edge_config.yaml`:
+
+```yaml
+endpoint: https://your-endpoint.openai.azure.com/
+api_key: sk-...
+deployment: gpt-35-turbo
+api_version: 2024-02-15-preview
+```
+
+## Running
+```
+python -m AG1_AetherBus.handlers.llm_edge_handler --config /path/to/llm.yaml
+```
+If `--config` is omitted, the handler reads credentials from environment variables.
+Ensure the Redis connection is configured via standard bus variables.
+
+### Registration
+Agents can announce their ability to use the LLM edge by publishing a
+registration Envelope to `AG1:edge:llm:register`. The helper
+`register_with_llm_handler` in `agent_bus_minimal.py` shows how to
+construct this envelope.
+
+## Message Flow
+1. Client publishes a prompt to `AG1:edge:llm:requests` with a `reply_to` stream
+2. The handler calls the Azure OpenAI Chat Completion API
+3. The response is wrapped in an Envelope and published to the `reply_to` stream
+
+---
+Contributions are welcome! Please update documentation and add tests for any new
+features.

--- a/docs/README_MAIL_EDGE.md
+++ b/docs/README_MAIL_EDGE.md
@@ -1,0 +1,34 @@
+# AG1 Core Bus – Mail Edge Handler
+
+The mail edge connector bridges IMAP/SMTP accounts to the AG1 bus. Each agent can register an email account so incoming emails are delivered to the agent inbox and agent replies are sent back via SMTP.
+
+## Registration
+Agents publish a registration envelope to `AG1:edge:mail:register` containing the IMAP/SMTP credentials:
+
+```json
+{
+  "envelope_type": "register",
+  "agent_name": "MuseMail",
+  "content": {
+    "username": "mybot@example.com",
+    "password": "app-password",
+    "imap_host": "imap.gmail.com",
+    "smtp_host": "smtp.gmail.com",
+    "smtp_port": 587
+  }
+}
+```
+An example configuration file is available at `examples/mail_edge_config.json`.
+
+On registration the handler starts polling the mailbox and subscribes to the agent reply channel `AG1:edge:mail:<username>:response`.
+
+## Message Flow
+1. New emails are fetched (but not deleted) via IMAP.
+2. Each message is published to the agent inbox `AG1:agent:<agent_name>:inbox` with the reply stream set to `AG1:edge:mail:<username>:response`.
+3. Replies from the agent on that stream are sent back to the mailbox via SMTP.
+
+## Running
+```
+python -m AG1_AetherBus.handlers.mail_edge.mail_edge_handler
+```
+Make sure the standard Redis environment variables are configured.

--- a/docs/README_NOSTR_EDGE.md
+++ b/docs/README_NOSTR_EDGE.md
@@ -1,0 +1,39 @@
+# AG1 Core Bus – Nostr Edge Handler
+
+This edge connector links the Nostr network to the AG1 bus. It listens for notes
+mentioning a registered public key and forwards them to the agent's inbox. Agent
+replies published to the corresponding response stream are sent back to the
+relay.
+
+## Registration
+Agents register by publishing an Envelope to `AG1:edge:nostr:register` with the
+Nostr details:
+
+```json
+{
+  "envelope_type": "register",
+  "agent_name": "MuseNostr",
+  "content": {
+    "pubkey": "npub1...",
+    "relay": "wss://relay.damus.io"
+  }
+}
+```
+
+An example config file is available at `examples/nostr_edge_config.json`.
+
+On registration the handler starts a WebSocket listener on the relay and
+subscribes to the agent reply channel `AG1:edge:nostr:<pubkey>:response`.
+
+## Message Flow
+1. Notes on the relay tagged with the agent's `pubkey` are received.
+2. Each note is published to `AG1:agent:<agent_name>:inbox` with the reply stream
+   set to `AG1:edge:nostr:<sender_pubkey>:response`.
+3. Agent replies on that stream are sent as simple notes back to the relay.
+
+## Running
+```
+python -m AG1_AetherBus.handlers.nostr_edge_handler
+```
+Ensure the Redis and relay credentials are configured. The handler requires the
+`websockets` package for network communication.

--- a/examples/llm_edge_config.yaml
+++ b/examples/llm_edge_config.yaml
@@ -1,0 +1,4 @@
+endpoint: https://your-endpoint.openai.azure.com/
+api_key: AZURE_API_KEY
+deployment: gpt-35-turbo
+api_version: 2024-02-15-preview

--- a/examples/mail_edge_config.json
+++ b/examples/mail_edge_config.json
@@ -1,0 +1,8 @@
+{
+  "username": "mybot@example.com",
+  "password": "app-password",
+  "imap_host": "imap.gmail.com",
+  "smtp_host": "smtp.gmail.com",
+  "smtp_port": 587
+}
+

--- a/examples/nostr_edge_config.json
+++ b/examples/nostr_edge_config.json
@@ -1,0 +1,5 @@
+{
+  "agent_name": "MuseNostr",
+  "pubkey": "npub1yourpublickey",
+  "relay": "wss://relay.damus.io"
+}

--- a/feature/experimental_attestation/README.md
+++ b/feature/experimental_attestation/README.md
@@ -1,0 +1,24 @@
+# Experimental Attestation Layer
+
+This proof-of-concept adds optional sender/receiver attestation for the AG1 bus.
+Messages are signed with an HMAC and stored in a small SQLite ledger. Consumers
+can verify the signature before processing the envelope.
+
+## Components
+
+- **crypto_utils.py** – Generates and verifies HMAC signatures for `Envelope`
+  objects. The `auth_signature` field is populated automatically.
+- **ledger.py** – Append-only SQLite store recording `(envelope_id, sender_id,
+  signature, timestamp)`.
+- **attestation_node.py** – Example helper that wraps `publish_envelope` and
+  `subscribe` with signing and verification logic.
+
+## Usage
+
+1. Set `ATTEST_SECRET` to the shared secret used for HMAC signing.
+2. Use `publish_with_attestation` and `subscribe_with_attestation` from
+   `attestation_node.py` instead of the core bus helpers.
+3. The ledger `attestations.db` is created in the current working directory.
+
+This directory is self-contained and does not modify the existing bus. It can be
+removed or ignored if attestation is not desired.

--- a/feature/experimental_attestation/attestation_node.py
+++ b/feature/experimental_attestation/attestation_node.py
@@ -1,0 +1,39 @@
+import asyncio
+import os
+from redis.asyncio import Redis
+
+from AG1_AetherBus.bus import publish_envelope, subscribe, build_redis_url
+from AG1_AetherBus.envelope import Envelope
+from AG1_AetherBus.keys import StreamKeyBuilder
+
+from .crypto_utils import apply_signature, verify_envelope
+from .ledger import Ledger
+
+SECRET = os.getenv("ATTEST_SECRET", "changeme")
+ledger = Ledger()
+keys = StreamKeyBuilder()
+
+async def publish_with_attestation(redis: Redis, channel: str, env: Envelope) -> None:
+    apply_signature(env, SECRET)
+    ledger.record(env.envelope_id, env.agent_name or env.user_id or "unknown", env.auth_signature or "", env.timestamp)
+    await publish_envelope(redis, channel, env)
+
+async def subscribe_with_attestation(redis: Redis, channel: str, callback, group: str = "attest", consumer: str | None = None) -> None:
+    async def verified(env: Envelope):
+        if verify_envelope(env, SECRET) and ledger.verify(env.envelope_id, env.auth_signature or ""):
+            await callback(env)
+        else:
+            print(f"[ATTN] Invalid signature for {env.envelope_id}")
+    await subscribe(redis, channel, verified, group=group, consumer=consumer)
+
+async def demo() -> None:
+    redis = Redis.from_url(build_redis_url())
+    test_stream = keys.agent_inbox("demo-agent")
+
+    async def handler(env: Envelope):
+        print(f"[ATTN-DEMO] Received: {env.content}")
+
+    await subscribe_with_attestation(redis, test_stream, handler)
+
+if __name__ == "__main__":
+    asyncio.run(demo())

--- a/feature/experimental_attestation/crypto_utils.py
+++ b/feature/experimental_attestation/crypto_utils.py
@@ -1,0 +1,28 @@
+import json
+import hmac
+import hashlib
+from typing import Any
+from AG1_AetherBus.envelope import Envelope
+
+
+def _canonical_bytes(env: Envelope) -> bytes:
+    data = env.to_dict().copy()
+    data.pop("auth_signature", None)
+    return json.dumps(data, sort_keys=True, separators=(",", ":")).encode()
+
+
+def sign_envelope(env: Envelope, secret: str) -> str:
+    """Return HMAC-SHA256 hex digest for the envelope."""
+    payload = _canonical_bytes(env)
+    return hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+
+
+def apply_signature(env: Envelope, secret: str) -> None:
+    env.auth_signature = sign_envelope(env, secret)
+
+
+def verify_envelope(env: Envelope, secret: str) -> bool:
+    if not env.auth_signature:
+        return False
+    expected = sign_envelope(env, secret)
+    return hmac.compare_digest(expected, env.auth_signature)

--- a/feature/experimental_attestation/ledger.py
+++ b/feature/experimental_attestation/ledger.py
@@ -1,0 +1,29 @@
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+
+class Ledger:
+    def __init__(self, path: str = "attestations.db"):
+        self.db = sqlite3.connect(path)
+        self.db.execute(
+            "CREATE TABLE IF NOT EXISTS attestations (envelope_id TEXT PRIMARY KEY, sender_id TEXT, signature TEXT, signed_at TEXT)"
+        )
+        self.db.commit()
+
+    def record(self, envelope_id: str, sender_id: str, signature: str, signed_at: str) -> None:
+        self.db.execute(
+            "INSERT OR REPLACE INTO attestations (envelope_id, sender_id, signature, signed_at) VALUES (?, ?, ?, ?)",
+            (envelope_id, sender_id, signature, signed_at),
+        )
+        self.db.commit()
+
+    def get_signature(self, envelope_id: str) -> Optional[str]:
+        row = self.db.execute(
+            "SELECT signature FROM attestations WHERE envelope_id=?", (envelope_id,)
+        ).fetchone()
+        return row[0] if row else None
+
+    def verify(self, envelope_id: str, signature: str) -> bool:
+        stored = self.get_signature(envelope_id)
+        return stored == signature

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 redis==5.2.1
 aiohttp
 python-dotenv
+openai
+PyYAML
+websockets


### PR DESCRIPTION
## Summary
- add a new `nostr_edge_handler` for bridging Nostr relays
- support Nostr registration from agents
- document the Nostr edge and provide a sample config
- mention `AG1:edge:nostr:register` in key table
- require `websockets` package

## Testing
- `pytest -q` *(fails: Python 3.11.8 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684251348318832285b0c43a692f882d